### PR TITLE
Shift to Builder methods on svdparser temporarily

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ name = "header2svd"
 version = "0.1.0"
 dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "svd-parser 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "svd-parser 0.9.0 (git+https://github.com/rust-embedded/svd.git?branch=build)",
  "xmltree 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -77,7 +77,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "svd-parser"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/rust-embedded/svd.git?branch=build#f8c26aa421a19b5fde91f7cde969b9985a246fca"
 dependencies = [
  "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -153,7 +153,7 @@ dependencies = [
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
-"checksum svd-parser 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4166295f1efb24fd50c42adc9728f58a30521410c7976bdd3239a33c76f1be2"
+"checksum svd-parser 0.9.0 (git+https://github.com/rust-embedded/svd.git?branch=build)" = "<none>"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6f357d1814b33bc2dc221243f8424104bfe72dbe911d5b71b3816a2dff1c977e"
 "checksum thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 
 [dependencies]
 regex = "1.3.1"
-svd-parser = { version = "0.9.0", features = ["unproven"] }
+svd-parser = { git = "https://github.com/rust-embedded/svd.git", branch = "build", features = ["unproven"] }
 xmltree = "0.8.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,10 @@ use header2svd::{parse_idf, Bits, Peripheral};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufWriter;
-use std::mem;
-use std::ptr;
 use svd_parser::{
-    bitrange::BitRangeType, encode::Encode, BitRange, Field, FieldInfo,
-    Peripheral as SvdPeripheral, Register as SvdRegister, RegisterCluster, RegisterInfo,
-    RegisterProperties,
+    bitrange::BitRangeType, encode::Encode, fieldinfo::FieldInfoBuilder,
+    peripheral::PeripheralBuilder, registerinfo::RegisterInfoBuilder, BitRange, Field,
+    Register as SvdRegister, RegisterCluster,
 };
 use xmltree::Element;
 
@@ -27,98 +25,56 @@ fn create_svd(peripherals: HashMap<String, Peripheral>) -> Result<Element, ()> {
     let mut svd_peripherals = vec![];
 
     for (name, p) in peripherals {
-        /*
-           Note on unsafe:
-           `mem::unitialized` is the only way to create these svd peripherals currently.
-           We must ensure that **all** the fields are initialized with a value
-           failure to do so will result in undefined behaviour when the value is dropped
-        */
-        let mut out: SvdPeripheral = unsafe { mem::uninitialized() };
-
         let mut registers = vec![];
         for r in p.registers {
-            let mut info: RegisterInfo = unsafe { mem::uninitialized() };
+            let mut fields = vec![];
+            for field in &r.bit_fields {
+                let description = if field.description.trim().is_empty() {
+                    None
+                } else {
+                    Some(field.description.clone())
+                };
 
-            unsafe {
-                ptr::write(&mut info.name, r.name.clone());
-                ptr::write(&mut info.alternate_group, None);
-                ptr::write(&mut info.alternate_register, None);
-                ptr::write(&mut info.derived_from, None);
-                ptr::write(&mut info.description, Some(r.description.clone()));
-                ptr::write(&mut info.address_offset, r.address);
-                ptr::write(&mut info.size, Some(32)); // TODO calc width
+                let bit_range = match &field.bits {
+                    Bits::Single(bit) => BitRange {
+                        offset: u32::from(*bit),
+                        width: 1,
+                        range_type: BitRangeType::OffsetWidth,
+                    },
+                    Bits::Range(r) => BitRange {
+                        offset: u32::from(*r.start()),
+                        width: u32::from(r.end() - r.start() + 1),
+                        range_type: BitRangeType::OffsetWidth,
+                    },
+                };
 
-                // TODO
-                ptr::write(&mut info.access, None);
-                ptr::write(&mut info.reset_value, Some(r.reset_value as u32));
-                ptr::write(&mut info.reset_mask, None);
-
-                let mut fields = vec![];
-                for field in &r.bit_fields {
-                    let mut field_out: FieldInfo = mem::uninitialized();
-                    ptr::write(&mut field_out.name, field.name.clone());
-                    ptr::write(
-                        &mut field_out.description,
-                        if field.description.trim().is_empty() {
-                            None
-                        } else {
-                            Some(field.description.clone())
-                        },
-                    );
-                    ptr::write(
-                        &mut field_out.bit_range,
-                        match &field.bits {
-                            Bits::Single(bit) => BitRange {
-                                offset: u32::from(*bit),
-                                width: 1,
-                                range_type: BitRangeType::OffsetWidth,
-                            },
-                            Bits::Range(r) => BitRange {
-                                offset: u32::from(*r.start()),
-                                width: u32::from(r.end() - r.start() + 1),
-                                range_type: BitRangeType::OffsetWidth,
-                            },
-                        },
-                    );
-                    // TODO
-                    ptr::write(&mut field_out.access, None);
-                    ptr::write(&mut field_out.enumerated_values, vec![]);
-                    ptr::write(&mut field_out.write_constraint, None);
-                    ptr::write(&mut field_out.modified_write_values, None);
-
-                    fields.push(Field::Single(field_out));
-                }
-
-                ptr::write(&mut info.fields, Some(fields));
-                ptr::write(&mut info.write_constraint, None);
-                ptr::write(&mut info.modified_write_values, None);
+                let field_out = FieldInfoBuilder::default()
+                    .name(field.name.clone())
+                    .description(description)
+                    .bit_range(bit_range)
+                    .build()
+                    .unwrap();
+                fields.push(Field::Single(field_out));
             }
+
+            let info = RegisterInfoBuilder::default()
+                .name(r.name.clone())
+                .description(Some(r.description.clone()))
+                .address_offset(r.address)
+                .size(Some(32))
+                .reset_value(Some(r.reset_value as u32))
+                .fields(Some(fields))
+                .build()
+                .unwrap();
 
             registers.push(RegisterCluster::Register(SvdRegister::Single(info)));
         }
-
-        unsafe {
-            ptr::write(&mut out.name, name.to_owned());
-            ptr::write(&mut out.version, None);
-            ptr::write(&mut out.display_name, None);
-            ptr::write(&mut out.group_name, None);
-            ptr::write(&mut out.description, None);
-            ptr::write(&mut out.base_address, p.address);
-            ptr::write(&mut out.address_block, None);
-            // TODO parse interrupt information
-            ptr::write(&mut out.interrupt, vec![]);
-
-            // TODO parse this information properly
-            let mut drp: RegisterProperties = mem::uninitialized();
-            ptr::write(&mut drp.access, None);
-            ptr::write(&mut drp.reset_mask, None);
-            ptr::write(&mut drp.reset_value, None);
-            ptr::write(&mut drp.size, None);
-
-            ptr::write(&mut out.default_register_properties, drp);
-            ptr::write(&mut out.registers, Some(registers));
-            ptr::write(&mut out.derived_from, None); // first.as_ref().map(|s| s.to_owned())
-        }
+        let out = PeripheralBuilder::default()
+            .name(name.to_owned())
+            .base_address(p.address)
+            .registers(Some(registers))
+            .build()
+            .unwrap();
 
         svd_peripherals.push(out.encode().unwrap());
     }


### PR DESCRIPTION
This is not currently a mainline feature, but once rust-embedded/svd#101 is merged it will be. Does currently cause builds of the SVD to fail as the builder methods check for name validity and some of the register names that idf2svd are generating are not valid due to including bracket characters.