### PR TITLE
Lazily match on index register offsets to avoid capturing comments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 pub const REG_BASE: &'static str = r"\#define[\s*]+DR_REG_(.*)_BASE[\s*]+0x([0-9a-fA-F]+)";
 pub const REG_DEF: &'static str = r"\#define[\s*]+([^\s*]+)_REG[\s*]+\(DR_REG_(.*)_BASE \+ (.*)\)";
 pub const REG_DEF_INDEX: &'static str =
-    r"\#define[\s*]+([^\s*]+)_REG\(i\)[\s*]+\(REG_([0-9A-Za-z_]+)_BASE[\s*]*\(i\) \+ (.*)\)";
+    r"\#define[\s*]+([^\s*]+)_REG\(i\)[\s*]+\(REG_([0-9A-Za-z_]+)_BASE[\s*]*\(i\) \+ (.*?)\)";
 pub const REG_BITS: &'static str =
     r"\#define[\s*]+([^\s*]+)_(S|V)[\s*]+\(?(0x[0-9a-fA-F]+|[0-9]+)\)?";
 pub const REG_BIT_INFO: &'static str =


### PR DESCRIPTION
See #6 . `FRC_TIMER_LOAD` and `FRC_TIMER_COUNT` were failing to parse due to the fact that both lines ended with comments ending with `)`. Lazily match on the final capture group to avoid this issue.