### PR TITLE
Add the ability to generate SVD for ESP8266

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /target
 **/*.rs.bk
-esp32.svd
+*.svd

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 *.svd
+build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "esp-idf"]
 	path = esp-idf
 	url = https://github.com/espressif/esp-idf
+[submodule "ESP8266_RTOS_SDK"]
+	path = ESP8266_RTOS_SDK
+	url = https://github.com/espressif/ESP8266_RTOS_SDK.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,8 @@ version = "0.1.0"
 dependencies = [
  "clap 3.0.0-beta.1 (git+https://github.com/clap-rs/clap/)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "svd-parser 0.9.0 (git+https://github.com/rust-embedded/svd.git?branch=build)",
  "xmltree 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -108,6 +110,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
@@ -179,6 +186,39 @@ dependencies = [
 name = "regex-syntax"
 version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ryu"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "strsim"
@@ -336,6 +376,7 @@ dependencies = [
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
@@ -345,6 +386,10 @@ dependencies = [
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
 "checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
+"checksum ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+"checksum serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
+"checksum serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
+"checksum serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)" = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
 "checksum strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 "checksum svd-parser 0.9.0 (git+https://github.com/rust-embedded/svd.git?branch=build)" = "<none>"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "header2svd"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap 3.0.0-beta.1 (git+https://github.com/clap-rs/clap/)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,14 +9,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/clap-rs/clap/#20daf00d519d12ec92923a7bde42cc9211823e69"
+dependencies = [
+ "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap_derive 3.0.0-beta.1 (git+https://github.com/clap-rs/clap/)",
+ "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/clap-rs/clap/#20daf00d519d12ec92923a7bde42cc9211823e69"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "either"
@@ -27,9 +79,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "header2svd"
 version = "0.1.0"
 dependencies = [
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 3.0.0-beta.1 (git+https://github.com/clap-rs/clap/)",
+ "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "svd-parser 0.9.0 (git+https://github.com/rust-embedded/svd.git?branch=build)",
- "xmltree 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xmltree 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -38,9 +115,38 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libc"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro-error"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-error-attr 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -60,18 +166,23 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.1"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.12"
+version = "0.6.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -96,6 +207,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,15 +244,54 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.3.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -135,6 +303,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml-rs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "xmltree"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,22 +315,53 @@ dependencies = [
  "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "xmltree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "xml-rs 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 "checksum anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14"
+"checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+"checksum clap 3.0.0-beta.1 (git+https://github.com/clap-rs/clap/)" = "<none>"
+"checksum clap_derive 3.0.0-beta.1 (git+https://github.com/clap-rs/clap/)" = "<none>"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
+"checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+"checksum proc-macro-error 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+"checksum proc-macro-error-attr 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
-"checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
-"checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+"checksum regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
+"checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
+"checksum strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 "checksum svd-parser 0.9.0 (git+https://github.com/rust-embedded/svd.git?branch=build)" = "<none>"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
+"checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6f357d1814b33bc2dc221243f8424104bfe72dbe911d5b71b3816a2dff1c977e"
 "checksum thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"
-"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+"checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
+"checksum xml-rs 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2bb76e5c421bbbeb8924c60c030331b345555024d56261dae8f3e786ed817c23"
+"checksum xmltree 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77a607efe600db25447a8d9bab1f39217a82c4ba160b51b027d7c4f6053004df"
 "checksum xmltree 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8eaee9d17062850f1e6163b509947969242990ee59a35801af437abe041e70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,25 @@
 [package]
 name = "header2svd"
-description = ""
-version = "0.1.0"
-authors = ["Scott Mabin <scott@mabez.dev>"]
+description = "A tool for generating SVD files for the ESP32 and ESP8266"
+version = "0.2.0"
+authors = [
+    "Scott Mabin <scott@mabez.dev>",
+    "Robin Appelman <robin@icewind.nl>",
+    "Jesse Braham <jesse@beta7.io",
+]
 repository = "https://github.com/MabezDev/idf2svd"
 edition = "2018"
-categories = []
-keywords = []
+categories = [
+    "command-line-utilities",
+    "embedded",
+    "hardware-support",
+]
+keywords = [
+    "embedded",
+    "esp32",
+    "esp8266",
+    "svd",
+]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-regex = "1.3.1"
+clap = { git = "https://github.com/clap-rs/clap/" }
+regex = "1.3.6"
 svd-parser = { git = "https://github.com/rust-embedded/svd.git", branch = "build", features = ["unproven"] }
-xmltree = "0.8.0"
+xmltree = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,19 @@
 [package]
 name = "header2svd"
+description = ""
 version = "0.1.0"
 authors = ["Scott Mabin <scott@mabez.dev>"]
+repository = "https://github.com/MabezDev/idf2svd"
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+categories = []
+keywords = []
+license = "MIT OR Apache-2.0"
+readme = "README.md"
 
 [dependencies]
 clap = { git = "https://github.com/clap-rs/clap/" }
 regex = "1.3.6"
+serde = { version = "1.0.106", features = ["derive"] }
+serde_json = "1.0.51"
 svd-parser = { git = "https://github.com/rust-embedded/svd.git", branch = "build", features = ["unproven"] }
 xmltree = "0.10.0"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+ Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2020 Contributors to header2svd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright 2020 Contributors to header2svd
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: all
+all: clean gpio.json spi.json uart.json timer.json
+
+clean:
+	rm -r build/
+
+esp8266-technical_reference_en.pdf:
+	mkdir build 2>/dev/null
+	wget https://www.espressif.com/sites/default/files/documentation/esp8266-technical_reference_en.pdf -O build/esp8266-technical_reference_en.pdf
+
+appendix.pdf: esp8266-technical_reference_en.pdf
+	qpdf --empty --pages build/esp8266-technical_reference_en.pdf 113-116 -- build/appendix.pdf
+
+tabula.jar:
+	wget https://github.com/tabulapdf/tabula-java/releases/download/v1.0.3/tabula-1.0.3-jar-with-dependencies.jar -O build/tabula.jar
+
+gpio.json: appendix.pdf tabula.jar
+	java -jar build/tabula.jar -p 1 -l -f JSON build/appendix.pdf -o build/gpio.json
+
+spi.json: appendix.pdf tabula.jar
+	java -jar build/tabula.jar -p 2 -l -f JSON build/appendix.pdf -o build/spi.json
+
+uart.json: appendix.pdf tabula.jar
+	java -jar build/tabula.jar -p 3 -l -f JSON build/appendix.pdf -o build/uart.json
+
+timer.json: appendix.pdf tabula.jar
+	java -jar build/tabula.jar -p 4 -l -f JSON build/appendix.pdf -o build/timer.json

--- a/README.md
+++ b/README.md
@@ -1,12 +1,59 @@
-# `idf2svd`
+# header2svd
 
-A tool for creating svd files from the [esp-idf](https://github.com/espressif/esp-idf) for the esp32. Currently targets the v4 release of esp idf.
+A tool for generating SVD files for the ESP32 and ESP8266. Uses [esp-idf] for the ESP32 and [ESP8266_RTOS_SDK] for the ESP8266.
+
+This tool is required because official SVD files are not available for these devices at this time.  The generated SVD files are used for generating the [esp32] and [esp8266] peripheral access crates using [svd2rust].
 
 ## Building
 
-Run `git clone --recursive https://github.com/MabezDev/idf2svd` to clone the repo and esp-idf, then execute
-```
-$ cd idf2svd && cargo run
+Clone the repository, [esp-idf], and [ESP8266_RTOS_SDK]. Move into the directory and build the application.
+
+```bash
+$ git clone --recursive https://github.com/MabezDev/idf2svd
+$ cd idf2svd/ && cargo build
 ```
 
-this will emit esp32.svd which can be used to generate register access through [svd2rust](https://github.com/rust-embedded/svd2rust)
+### ESP32
+
+```bash
+$ cargo run esp32
+```
+
+This will create the file `esp32.svd` in the base project directory.
+
+### ESP8266
+
+It is necessary to have `java`, `make`, `qpdf`, and `wget` installed on your system and available on `PATH`. These can generally be installed via your operating system's package manager.
+
+```bash
+$ # `make` only needs to be run once upon checking out the repository. It
+$ # takes care of downloading some additional tools and resources for
+$ # generating the ESP8266 SVD.
+$ make
+$ cargo run esp8266
+```
+
+This will create the file `esp8266.svd` in the base project directory.
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+
+[esp-idf]: https://github.com/espressif/esp-idf
+[ESP8266_RTOS_SDK]: https://github.com/espressif/ESP8266_RTOS_SDK
+[esp32]: https://github.com/esp-rs/esp32
+[esp8266]: https://github.com/esp-rs/esp8266
+[svd2rust]: https://github.com/rust-embedded/svd2rust

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,0 +1,225 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::prelude::*;
+use std::ops::RangeInclusive;
+use std::str::FromStr;
+
+use svd_parser::{
+    addressblock::AddressBlock, bitrange::BitRangeType, cpu::CpuBuilder, device::DeviceBuilder,
+    endian::Endian, fieldinfo::FieldInfoBuilder, peripheral::PeripheralBuilder,
+    registerinfo::RegisterInfoBuilder, Access, BitRange, Device as SvdDevice, Field,
+    Register as SvdRegister, RegisterCluster,
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct Peripheral {
+    pub description: String,
+    pub address: u32,
+    pub registers: Vec<Register>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Interrupt {
+    pub name: String,
+    pub description: Option<String>,
+    pub value: u32,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Register {
+    /// Register Name
+    pub name: String,
+    /// Relative Address
+    pub address: u32,
+    /// Width
+    pub width: u8,
+    /// Description
+    pub description: String,
+    /// Reset Value
+    pub reset_value: u64,
+    /// Detailed description
+    pub detailed_description: Option<String>,
+    pub bit_fields: Vec<BitField>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct BitField {
+    /// Field Name
+    pub name: String,
+    /// Bits
+    pub bits: Bits,
+    /// Type
+    pub type_: Type,
+    /// Reset Value
+    pub reset_value: u32,
+    /// Description
+    pub description: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum Bits {
+    Single(u8),
+    Range(RangeInclusive<u8>),
+}
+
+impl Default for Bits {
+    fn default() -> Self {
+        Bits::Single(0)
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum Type {
+    // ReadAsZero,
+    ReadOnly,
+    ReadWrite,
+    WriteOnly,
+    // ReadWriteSetOnly,
+    // ReadableClearOnRead,
+    // ReadableClearOnWrite,
+    // WriteAsZero,
+    // WriteToClear,
+}
+
+impl From<Type> for Access {
+    fn from(t: Type) -> Self {
+        match t {
+            Type::ReadOnly => Access::ReadOnly,
+            Type::ReadWrite => Access::ReadWrite,
+            Type::WriteOnly => Access::WriteOnly,
+        }
+    }
+}
+
+impl Default for Type {
+    fn default() -> Type {
+        Type::ReadWrite
+    }
+}
+
+impl FromStr for Type {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Type, Self::Err> {
+        Ok(match s {
+            "RO" | "R/O" => Type::ReadOnly,
+            "RW" | "R/W" => Type::ReadWrite,
+            "WO" | "W/O" => Type::WriteOnly,
+            _ => return Err(String::from("Invalid BitField type: ") + &String::from(s)),
+        })
+    }
+}
+
+pub fn file_to_string(file: &str) -> String {
+    let mut soc = File::open(file).unwrap();
+    let mut data = String::new();
+    soc.read_to_string(&mut data).unwrap();
+
+    data
+}
+
+pub fn build_svd(
+    cpu_name: String,
+    peripherals: HashMap<String, Peripheral>,
+) -> Result<SvdDevice, ()> {
+    let mut svd_peripherals = vec![];
+
+    for (name, p) in peripherals {
+        let mut registers = vec![];
+        for r in p.registers {
+            let mut fields = vec![];
+            for field in &r.bit_fields {
+                let description = if field.description.trim().is_empty() {
+                    None
+                } else {
+                    Some(field.description.clone())
+                };
+
+                let bit_range = match &field.bits {
+                    Bits::Single(bit) => BitRange {
+                        offset: u32::from(*bit),
+                        width: 1,
+                        range_type: BitRangeType::OffsetWidth,
+                    },
+                    Bits::Range(r) => BitRange {
+                        offset: u32::from(*r.start()),
+                        width: u32::from(r.end() - r.start() + 1),
+                        range_type: BitRangeType::OffsetWidth,
+                    },
+                };
+
+                let field_out = FieldInfoBuilder::default()
+                    .name(field.name.clone())
+                    .description(description)
+                    .bit_range(bit_range)
+                    .access(Some(field.type_.into()))
+                    .build()
+                    .unwrap();
+                fields.push(Field::Single(field_out));
+            }
+
+            let info = RegisterInfoBuilder::default()
+                .name(r.name.clone())
+                .description(Some(r.description.clone()))
+                .address_offset(r.address)
+                .size(Some(32))
+                .reset_value(Some(r.reset_value as u32))
+                .fields(Some(fields))
+                .build()
+                .unwrap();
+
+            registers.push(RegisterCluster::Register(SvdRegister::Single(info)));
+        }
+        let block_size = registers.iter().fold(0, |sum, reg| {
+            sum + match reg {
+                RegisterCluster::Register(r) => r.size.unwrap(),
+                _ => unimplemented!(),
+            }
+        });
+        let out = PeripheralBuilder::default()
+            .name(name.to_owned())
+            .base_address(p.address)
+            .registers(Some(registers))
+            .address_block(Some(AddressBlock {
+                offset: 0x0,
+                size: block_size, // TODO what about derived peripherals?
+                usage: "registers".to_string(),
+            }))
+            .build()
+            .unwrap();
+
+        svd_peripherals.push(out);
+    }
+
+    svd_peripherals.sort_by(|a, b| a.name.cmp(&b.name));
+
+    println!("Len {}", svd_peripherals.len());
+
+    let cpu = CpuBuilder::default()
+        .name(cpu_name)
+        .revision("1".to_string())
+        .endian(Endian::Little)
+        .mpu_present(false)
+        .fpu_present(true)
+        // according to https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/system/intr_alloc.html#macros
+        // 7 levels so 3 bits? //TODO verify
+        .nvic_priority_bits(3)
+        .has_vendor_systick(false)
+        .build()
+        .unwrap();
+
+    let device = DeviceBuilder::default()
+        .name("Espressif".to_string())
+        .version(Some("1.0".to_string()))
+        .schema_version(Some("1.0".to_string()))
+        // broken see: https://github.com/rust-embedded/svd/pull/104
+        // .description(Some("ESP32".to_string()))
+        // .address_unit_bits(Some(8))
+        .width(Some(32))
+        .cpu(Some(cpu))
+        .peripherals(svd_peripherals)
+        .build()
+        .unwrap();
+
+    Ok(device)
+}

--- a/src/idf/mod.rs
+++ b/src/idf/mod.rs
@@ -1,16 +1,13 @@
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::prelude::*;
 use std::io::BufWriter;
-use std::ops::RangeInclusive;
 use std::str::FromStr;
 
 use regex::Regex;
-use svd_parser::{
-    addressblock::AddressBlock, bitrange::BitRangeType, cpu::CpuBuilder, device::DeviceBuilder,
-    encode::Encode, endian::Endian, fieldinfo::FieldInfoBuilder, peripheral::PeripheralBuilder,
-    registerinfo::RegisterInfoBuilder, Access, BitRange, Device as SvdDevice, Field,
-    Register as SvdRegister, RegisterCluster,
+use svd_parser::encode::Encode;
+
+use crate::common::{
+    build_svd, file_to_string, BitField, Bits, Interrupt, Peripheral, Register, Type,
 };
 
 const SOC_BASE_PATH: &'static str = "esp-idf/components/soc/esp32/include/soc/";
@@ -24,105 +21,6 @@ const REG_BIT_INFO: &'static str = r"/\*[\s]+([0-9A-Za-z_]+)[\s]+:[\s]+([0-9A-Za
 const REG_DESC: &'static str = r"\*description:\s(.*[\n|\r|\r\n]?.*)\*/";
 const INTERRUPTS: &'static str =
     r"\#define[\s]ETS_([0-9A-Za-z_/]+)_SOURCE[\s]+([0-9]+)/\*\*<\s([0-9A-Za-z_/\s,]+)\*/";
-
-#[derive(Debug, Default, Clone)]
-pub struct Peripheral {
-    pub description: String,
-    pub address: u32,
-    pub registers: Vec<Register>,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct Interrupt {
-    pub name: String,
-    pub description: Option<String>,
-    pub value: u32,
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct Register {
-    /// Register Name
-    pub name: String,
-    /// Relative Address
-    pub address: u32,
-    /// Width
-    pub width: u8,
-    /// Description
-    pub description: String,
-    /// Reset Value
-    pub reset_value: u64,
-    /// Detailed description
-    pub detailed_description: Option<String>,
-    pub bit_fields: Vec<BitField>,
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct BitField {
-    /// Field Name
-    pub name: String,
-    /// Bits
-    pub bits: Bits,
-    /// Type
-    pub type_: Type,
-    /// Reset Value
-    pub reset_value: u32,
-    /// Description
-    pub description: String,
-}
-
-#[derive(Debug, Clone)]
-pub enum Bits {
-    Single(u8),
-    Range(RangeInclusive<u8>),
-}
-
-impl Default for Bits {
-    fn default() -> Self {
-        Bits::Single(0)
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
-pub enum Type {
-    // ReadAsZero,
-    ReadOnly,
-    ReadWrite,
-    WriteOnly,
-    // ReadWriteSetOnly,
-    // ReadableClearOnRead,
-    // ReadableClearOnWrite,
-    // WriteAsZero,
-    // WriteToClear,
-}
-
-impl From<Type> for Access {
-    fn from(t: Type) -> Self {
-        match t {
-            Type::ReadOnly => Access::ReadOnly,
-            Type::ReadWrite => Access::ReadWrite,
-            Type::WriteOnly => Access::WriteOnly,
-        }
-    }
-}
-
-impl Default for Type {
-    fn default() -> Type {
-        Type::ReadWrite
-    }
-}
-
-impl FromStr for Type {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Type, Self::Err> {
-        Ok(match s {
-            "RO" | "R/O" => Type::ReadOnly,
-            "RW" | "R/W" => Type::ReadWrite,
-            "WO" | "W/O" => Type::WriteOnly,
-            _ => return Err(String::from("Invalid BitField type: ") + &String::from(s)),
-        })
-    }
-}
 
 enum State {
     FindReg,
@@ -348,115 +246,10 @@ fn parse_idf() -> HashMap<String, Peripheral> {
     peripherals
 }
 
-fn file_to_string(fil: &str) -> String {
-    let mut soc = File::open(fil).unwrap();
-    let mut data = String::new();
-    soc.read_to_string(&mut data).unwrap();
-    data
-}
-
-fn build_svd(peripherals: HashMap<String, Peripheral>) -> Result<SvdDevice, ()> {
-    let mut svd_peripherals = vec![];
-
-    for (name, p) in peripherals {
-        let mut registers = vec![];
-        for r in p.registers {
-            let mut fields = vec![];
-            for field in &r.bit_fields {
-                let description = if field.description.trim().is_empty() {
-                    None
-                } else {
-                    Some(field.description.clone())
-                };
-
-                let bit_range = match &field.bits {
-                    Bits::Single(bit) => BitRange {
-                        offset: u32::from(*bit),
-                        width: 1,
-                        range_type: BitRangeType::OffsetWidth,
-                    },
-                    Bits::Range(r) => BitRange {
-                        offset: u32::from(*r.start()),
-                        width: u32::from(r.end() - r.start() + 1),
-                        range_type: BitRangeType::OffsetWidth,
-                    },
-                };
-
-                let field_out = FieldInfoBuilder::default()
-                    .name(field.name.clone())
-                    .description(description)
-                    .bit_range(bit_range)
-                    .build()
-                    .unwrap();
-                fields.push(Field::Single(field_out));
-            }
-
-            let info = RegisterInfoBuilder::default()
-                .name(r.name.clone())
-                .description(Some(r.description.clone()))
-                .address_offset(r.address)
-                .size(Some(32))
-                .reset_value(Some(r.reset_value as u32))
-                .fields(Some(fields))
-                .build()
-                .unwrap();
-
-            registers.push(RegisterCluster::Register(SvdRegister::Single(info)));
-        }
-        let block_size = registers.iter().fold(0, |sum, reg| {
-            sum + match reg {
-                RegisterCluster::Register(r) => r.size.unwrap(),
-                _ => unimplemented!(),
-            }
-        });
-        let out = PeripheralBuilder::default()
-            .name(name.to_owned())
-            .base_address(p.address)
-            .registers(Some(registers))
-            .address_block(Some(AddressBlock {
-                offset: 0x0,
-                size: block_size, // TODO what about derived peripherals?
-                usage: "registers".to_string(),
-            }))
-            .build()
-            .unwrap();
-
-        svd_peripherals.push(out);
-    }
-    println!("Len {}", svd_peripherals.len());
-
-    let cpu = CpuBuilder::default()
-        .name("Xtensa LX6".to_string())
-        .revision("1".to_string())
-        .endian(Endian::Little)
-        .mpu_present(false)
-        .fpu_present(true)
-        // according to https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/system/intr_alloc.html#macros
-        // 7 levels so 3 bits? //TODO verify
-        .nvic_priority_bits(3)
-        .has_vendor_systick(false)
-        .build()
-        .unwrap();
-
-    let device = DeviceBuilder::default()
-        .name("Espressif".to_string())
-        .version(Some("1.0".to_string()))
-        .schema_version(Some("1.0".to_string()))
-        // broken see: https://github.com/rust-embedded/svd/pull/104
-        // .description(Some("ESP32".to_string()))
-        // .address_unit_bits(Some(8))
-        .width(Some(32))
-        .cpu(Some(cpu))
-        .peripherals(svd_peripherals)
-        .build()
-        .unwrap();
-
-    Ok(device)
-}
-
 pub fn create_svd() {
+    let cpu_name = String::from("Xtensa LX6");
     let peripherals = parse_idf();
-    let svd = build_svd(peripherals).unwrap();
+    let svd = build_svd(cpu_name, peripherals).unwrap();
 
     let f = BufWriter::new(File::create("esp32.svd").unwrap());
     svd.encode().unwrap().write(f).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,121 +1,26 @@
-pub const SOC_BASE_PATH: &'static str = "esp-idf/components/soc/esp32/include/soc/";
+use clap::{app_from_crate, Arg};
 
-use header2svd::{parse_idf, Bits, Peripheral};
-
-use std::collections::HashMap;
-use std::fs::File;
-use std::io::BufWriter;
-use svd_parser::{
-    addressblock::AddressBlock, bitrange::BitRangeType, cpu::CpuBuilder, device::DeviceBuilder,
-    encode::Encode, endian::Endian, fieldinfo::FieldInfoBuilder, peripheral::PeripheralBuilder,
-    registerinfo::RegisterInfoBuilder, BitRange, Device as SvdDevice, Field,
-    Register as SvdRegister, RegisterCluster,
-};
+mod idf;
+mod sdk;
 
 fn main() {
-    let peripherals = parse_idf(SOC_BASE_PATH);
+    let matches = app_from_crate!("\n")
+        .arg(
+            Arg::with_name("CHIP")
+                .help("select which device to target")
+                .required(true)
+                .index(1)
+                .possible_values(&["ESP32", "ESP8266"])
+                .case_insensitive(true),
+        )
+        .get_matches();
 
-    let svd = create_svd(peripherals).unwrap();
-
-    let f = BufWriter::new(File::create("esp32.svd").unwrap());
-    svd.encode().unwrap().write(f).unwrap();
-}
-
-fn create_svd(peripherals: HashMap<String, Peripheral>) -> Result<SvdDevice, ()> {
-    let mut svd_peripherals = vec![];
-
-    for (name, p) in peripherals {
-        let mut registers = vec![];
-        for r in p.registers {
-            let mut fields = vec![];
-            for field in &r.bit_fields {
-                let description = if field.description.trim().is_empty() {
-                    None
-                } else {
-                    Some(field.description.clone())
-                };
-
-                let bit_range = match &field.bits {
-                    Bits::Single(bit) => BitRange {
-                        offset: u32::from(*bit),
-                        width: 1,
-                        range_type: BitRangeType::OffsetWidth,
-                    },
-                    Bits::Range(r) => BitRange {
-                        offset: u32::from(*r.start()),
-                        width: u32::from(r.end() - r.start() + 1),
-                        range_type: BitRangeType::OffsetWidth,
-                    },
-                };
-
-                let field_out = FieldInfoBuilder::default()
-                    .name(field.name.clone())
-                    .description(description)
-                    .bit_range(bit_range)
-                    .build()
-                    .unwrap();
-                fields.push(Field::Single(field_out));
-            }
-
-            let info = RegisterInfoBuilder::default()
-                .name(r.name.clone())
-                .description(Some(r.description.clone()))
-                .address_offset(r.address)
-                .size(Some(32))
-                .reset_value(Some(r.reset_value as u32))
-                .fields(Some(fields))
-                .build()
-                .unwrap();
-
-            registers.push(RegisterCluster::Register(SvdRegister::Single(info)));
-        }
-        let block_size = registers.iter().fold(0, |sum, reg| {
-            sum + match reg {
-                RegisterCluster::Register(r) => r.size.unwrap(),
-                _ => unimplemented!(),
-            }
-        });
-        let out = PeripheralBuilder::default()
-            .name(name.to_owned())
-            .base_address(p.address)
-            .registers(Some(registers))
-            .address_block(Some(AddressBlock {
-                offset: 0x0,
-                size: block_size, // TODO what about derived peripherals?
-                usage: "registers".to_string(),
-            }))
-            .build()
-            .unwrap();
-
-        svd_peripherals.push(out);
+    // Based on which chip has been selected, invoke the appropriate SVD
+    // builder (since the ESP32 and ESP8266 have different SDKs).
+    let chip = matches.value_of("CHIP").unwrap().to_uppercase();
+    match chip.as_str() {
+        "ESP32" => idf::create_svd(),
+        "ESP8266" => sdk::create_svd(),
+        _ => unimplemented!(),
     }
-    println!("Len {}", svd_peripherals.len());
-
-    let cpu = CpuBuilder::default()
-        .name("Xtensa LX6".to_string())
-        .revision("1".to_string())
-        .endian(Endian::Little)
-        .mpu_present(false)
-        .fpu_present(true)
-        // according to https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/system/intr_alloc.html#macros
-        // 7 levels so 3 bits? //TODO verify
-        .nvic_priority_bits(3)
-        .has_vendor_systick(false)
-        .build()
-        .unwrap();
-
-    let device = DeviceBuilder::default()
-        .name("Espressif".to_string())
-        .version(Some("1.0".to_string()))
-        .schema_version(Some("1.0".to_string()))
-        // broken see: https://github.com/rust-embedded/svd/pull/104
-        // .description(Some("ESP32".to_string()))
-        // .address_unit_bits(Some(8))
-        .width(Some(32))
-        .cpu(Some(cpu))
-        .peripherals(svd_peripherals)
-        .build()
-        .unwrap();
-
-    Ok(device)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
     let matches = app_from_crate!("\n")
         .arg(
             Arg::with_name("CHIP")
-                .help("select which device to target")
+                .help("which device's SVD to generate")
                 .required(true)
                 .index(1)
                 .possible_values(&["ESP32", "ESP8266"])

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{app_from_crate, Arg};
 
+mod common;
 mod idf;
 mod sdk;
 

--- a/src/sdk/doc_input.rs
+++ b/src/sdk/doc_input.rs
@@ -1,0 +1,42 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct JSONInput {
+    data: Vec<Vec<Column>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Column {
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(from = "Vec<JSONInput>")]
+pub struct Table {
+    pub header: Vec<String>,
+    pub data: Vec<Vec<String>>,
+}
+
+impl From<Vec<JSONInput>> for Table {
+    fn from(mut input: Vec<JSONInput>) -> Self {
+        let input = input.pop().unwrap();
+        let mut data = input.data.into_iter().skip(1); // first row is garbage
+
+        let header = loop {
+            let header = data.next().unwrap();
+            if !header[4].text.is_empty() {
+                break header
+                    .into_iter()
+                    .map(|c| c.text.replace("\r", ""))
+                    .collect();
+            }
+        };
+
+        Table {
+            header,
+            data: data
+                .map(|row| row.into_iter().map(|c| c.text).collect())
+                .collect(),
+        }
+    }
+}

--- a/src/sdk/doc_parse.rs
+++ b/src/sdk/doc_parse.rs
@@ -1,0 +1,163 @@
+use std::fs::read_to_string;
+use std::str::FromStr;
+
+use crate::sdk::doc_input::Table;
+use crate::sdk::{BitField, Bits, Peripheral, Register, Type};
+
+struct Row {
+    address: Option<u32>,
+    reg_name: String,
+    signal: String,
+    bit_pos: Option<Bits>,
+    default: Option<u32>,
+    ty: Option<Type>,
+    description: String,
+}
+
+fn decode_table(input: Table) -> Peripheral {
+    let gpio_mode = input.header[0] == "NUM";
+    let mut peripheral = Peripheral::default();
+
+    let mut reg = Register::default();
+    let mut last_type = Type::ReadWrite;
+    for line in input.data {
+        if line[0].contains('~') {
+            continue;
+        }
+
+        let row = extract_row(line, gpio_mode);
+        if row.address.is_some() {
+            // start of new register, push the old one
+            if !reg.name.is_empty() {
+                peripheral.registers.push(reg.clone());
+            }
+
+            reg = Register::default();
+            reg.width = 32;
+            reg.address = row.address.unwrap();
+            reg.name = row.reg_name.trim_end_matches("_ADDRESS").to_string();
+            reg.description = if row.description.is_empty() {
+                reg.name.clone()
+            } else {
+                row.description.clone()
+            };
+        }
+
+        if !row.signal.is_empty()
+            && row.bit_pos.is_some()
+            && (row.ty.is_some() || !row.signal.is_empty())
+        {
+            // start of new bitfield
+            let bit_field = BitField {
+                name: row.signal,
+                bits: row.bit_pos.unwrap(),
+                description: row.description,
+                reset_value: row.default.unwrap_or_default(),
+                type_: row.ty.unwrap_or(last_type),
+            };
+
+            last_type = bit_field.type_;
+            reg.bit_fields.push(bit_field);
+        } else if !row.description.is_empty() {
+            if let Some(last_bit_field) = reg.bit_fields.last_mut() {
+                last_bit_field.description.push_str(", ");
+                last_bit_field.description.push_str(&row.description)
+            }
+        }
+    }
+
+    peripheral
+}
+
+fn extract_row(line: Vec<String>, gpio_mode: bool) -> Row {
+    if gpio_mode {
+        let mut parts = line.into_iter().skip(1).map(|part| part.replace('\r', ""));
+        let address = parts.next().unwrap();
+        let _ = parts.next();
+        let reg_name = parts.next().unwrap();
+        let signal = parts.next().unwrap();
+        let bit_pos = parts.next().unwrap();
+        let sw = parts.next().unwrap();
+        let description = parts.next().unwrap();
+
+        Row {
+            address: parse_addr(&address).map(|addr| addr * 4),
+            reg_name,
+            signal,
+            bit_pos: parse_bits(&bit_pos),
+            default: None,
+            ty: Type::from_str(&sw).ok(),
+            description,
+        }
+    } else {
+        let mut parts = line.into_iter().map(|part| part.replace('\r', ""));
+        let mut address = parts.next().unwrap();
+        let reg_name = parts.next().unwrap();
+        let signal = parts.next().unwrap();
+        let bit_pos = parts.next().unwrap();
+        let default = parts.next().unwrap();
+        let sw = parts.next().unwrap();
+        let description = parts.next().unwrap();
+
+        // broken row in the table
+        if reg_name == "UART_STATUS" {
+            address = "0x1c".to_string();
+        }
+
+        Row {
+            address: parse_addr(&address),
+            reg_name,
+            signal,
+            bit_pos: parse_bits(&bit_pos),
+            default: parse_default(&default),
+            ty: Type::from_str(&sw).ok(),
+            description,
+        }
+    }
+}
+
+fn parse_addr(addr: &str) -> Option<u32> {
+    if addr.is_empty() || addr.contains('~') {
+        return None;
+    }
+    Some(u32::from_str_radix(&addr.trim_start_matches("0x"), 16).unwrap())
+}
+
+fn parse_bits(bit_pos: &str) -> Option<Bits> {
+    if bit_pos.is_empty() {
+        return None;
+    }
+
+    let nums = bit_pos.trim_start_matches('[').trim_end_matches(']');
+    let parts: Vec<u8> = nums
+        .split(':')
+        .map(|digits| u8::from_str(digits).unwrap())
+        .collect();
+
+    Some(if parts.len() == 1 {
+        Bits::Single(parts[0])
+    } else {
+        Bits::Range(parts[1]..=parts[0])
+    })
+}
+
+fn parse_default(default: &str) -> Option<u32> {
+    if default.is_empty() {
+        return None;
+    }
+
+    let default = default.split('\'').skip(1).next().unwrap().replace('_', "");
+    Some(match &default[..1] {
+        "b" => u32::from_str_radix(&default[1..], 2).unwrap(),
+        "d" => u32::from_str_radix(&default[1..], 10).unwrap(),
+        "h" => u32::from_str_radix(&default[1..], 16).unwrap(),
+        _ => panic!("invalid default format"),
+    })
+}
+
+pub fn parse_doc(name: &str) -> Peripheral {
+    let file = read_to_string(name).unwrap();
+    let input = serde_json::from_str(&file).unwrap();
+
+    decode_table(input)
+}

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -1,0 +1,4 @@
+pub fn create_svd() {
+    // TODO: implement me
+    unimplemented!()
+}

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -1,4 +1,646 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::BufWriter;
+use std::ops::RangeInclusive;
+use std::str::FromStr;
+
+use regex::Regex;
+use svd_parser::{
+    addressblock::AddressBlock, bitrange::BitRangeType, cpu::CpuBuilder, device::DeviceBuilder,
+    encode::Encode, endian::Endian, fieldinfo::FieldInfoBuilder, peripheral::PeripheralBuilder,
+    registerinfo::RegisterInfoBuilder, Access, BitRange, Device as SvdDevice, Field,
+    Register as SvdRegister, RegisterCluster,
+};
+
+mod doc_input;
+mod doc_parse;
+
+pub use doc_parse::parse_doc;
+
+pub const SOC_BASE_PATH: &'static str = "ESP8266_RTOS_SDK/components/esp8266/include/esp8266/";
+
+// make the header a bit more easy to handle
+const REPLACEMENTS: &'static [(&'static str, &'static str)] = &[
+    ("PERIPHS_IO_MUX ", "PERIPHS_IO_MUX_BASE "),
+    ("RTC_STORE0", "RTC_STORE0_REG"),
+    ("RTC_STATE1", "RTC_STATE1_REG"),
+    ("RTC_STATE2", "RTC_STATE2_REG"),
+    ("(0x60000000 + (i)*0xf00)", "0x60000000"), // uart base address
+];
+const REPLACEMENTS_REGEX: &'static [(&'static str, &'static str)] = &[
+    (r"(I2S[^\s]+)[\s]+(\(REG_I2S_BASE \+ )", "${1}_REG $2"),
+    (r"(SLC_[^\s]+)[\s]+(\(REG_SLC_BASE \+ )", "${1}_REG $2"),
+];
+
+/* Regex's to find all the peripheral addresses */
+pub const REG_BASE: &'static str =
+    r"\#define[\s*]+(?:DR_REG|REG|PERIPHS)_(.*)_BASE(?:_?A?DDR)?[\s*]+\(?0x([0-9a-fA-F]+)\)?";
+pub const REG_DEF: &'static str = r"\#define[\s*]+(?:PERIPHS_)?([^\s*]+)_(?:REG|ADDRESS|U|ADDR)[\s*]+\((?:DR_REG|REG|PERIPHS)_(.*)_BASE(?:_?A?DDR)? \+ (.*)\)";
+pub const REG_DEF_OFFSET: &'static str =
+    r"\#define[\s*]+(?:PERIPHS_)?([^\s*]+)_(?:ADDRESS|U|ADDR)[\s*]+(?:0x)?([0-9a-fA-F]+)";
+pub const REG_DEF_INDEX: &'static str = r"\#define[\s*]+(?:PERIPHS_)?([^\s*]+)_(?:REG|ADDRESS|U|ADDR)\(i\)[\s*]+\((?:DR_REG|REG|PERIPHS)_([0-9A-Za-z_]+)_BASE(?:_?A?DDR)?[\s*]*\(i\) \+ (.*?)\)";
+pub const REG_DEFINE_MASK: &'static str = r"\#define[\s*]+(?:PERIPHS_)?([^\s*]+)[\s*]+\(?(0x[0-9a-fA-F]+|[0-9]+|\(?BIT\(?[0-9]+\)?)\)?\)?";
+pub const REG_DEFINE_SHIFT: &'static str =
+    r"\#define[\s*]+(?:PERIPHS_)?([^\s*]+)_(?:S|s)[\s*]+\(?(0x[0-9a-fA-F]+|[0-9]+)\)?";
+pub const REG_DEFINE_SKIP: &'static str =
+    r"\#define[\s*]+(?:PERIPHS_)?([^\s*]+)_(?:M|V)[\s*]+(\(|0x)";
+pub const SINGLE_BIT: &'static str = r"BIT\(?([0-9]+)\)?";
+pub const INTERRUPTS: &'static str =
+    r"\#define[\s]ETS_([0-9A-Za-z_/]+)_SOURCE[\s]+([0-9]+)/\*\*<\s([0-9A-Za-z_/\s,]+)\*/";
+pub const REG_IFDEF: &'static str = r"#ifn?def.*";
+pub const REG_ENDIF: &'static str = r"#endif";
+
+#[derive(Debug, Default, Clone)]
+pub struct Peripheral {
+    pub description: String,
+    pub address: u32,
+    pub registers: Vec<Register>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Interrupt {
+    pub name: String,
+    pub description: Option<String>,
+    pub value: u32,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Register {
+    /// Register Name
+    pub name: String,
+    /// Relative Address
+    pub address: u32,
+    /// Width
+    pub width: u8,
+    /// Description
+    pub description: String,
+    /// Reset Value
+    pub reset_value: u64,
+    /// Detailed description
+    pub detailed_description: Option<String>,
+    pub bit_fields: Vec<BitField>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct BitField {
+    /// Field Name
+    pub name: String,
+    /// Bits
+    pub bits: Bits,
+    /// Type
+    pub type_: Type,
+    /// Reset Value
+    pub reset_value: u32,
+    /// Description
+    pub description: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum Bits {
+    Single(u8),
+    Range(RangeInclusive<u8>),
+}
+
+impl Default for Bits {
+    fn default() -> Self {
+        Bits::Single(0)
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum Type {
+    // ReadAsZero,
+    ReadOnly,
+    ReadWrite,
+    WriteOnly,
+    // ReadWriteSetOnly,
+    // ReadableClearOnRead,
+    // ReadableClearOnWrite,
+    // WriteAsZero,
+    // WriteToClear,
+}
+
+impl From<Type> for Access {
+    fn from(t: Type) -> Self {
+        match t {
+            Type::ReadOnly => Access::ReadOnly,
+            Type::ReadWrite => Access::ReadWrite,
+            Type::WriteOnly => Access::WriteOnly,
+        }
+    }
+}
+
+impl Default for Type {
+    fn default() -> Type {
+        Type::ReadWrite
+    }
+}
+
+impl FromStr for Type {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Type, Self::Err> {
+        Ok(match s {
+            "RO" | "R/O" => Type::ReadOnly,
+            "RW" | "R/W" => Type::ReadWrite,
+            "WO" | "W/O" => Type::WriteOnly,
+            _ => return Err(String::from("Invalid BitField type: ") + &String::from(s)),
+        })
+    }
+}
+
+enum State {
+    FindReg,
+    FindBitFieldMask(String, Register),
+    FindBitFieldShift(String, Register, u32),
+    FindBitFieldSkipShift(String, Register),
+    AssumeFullRegister(String, Register),
+    CheckEnd(String, Register),
+    End(String, Register),
+}
+
+fn add_base_addr(header: &str, peripherals: &mut HashMap<String, Peripheral>) {
+    let re_base = Regex::new(REG_BASE).unwrap();
+    /* Peripheral base addresses */
+    for captures in re_base.captures_iter(header) {
+        let peripheral = &captures[1];
+        let address = &captures[2];
+        let mut p = Peripheral::default();
+        p.address = u32::from_str_radix(address, 16).unwrap();
+        p.description = peripheral.to_string();
+
+        if !peripherals.contains_key(peripheral) {
+            peripherals.insert(peripheral.to_string(), p);
+        }
+    }
+}
+
+fn parse_sdk() -> HashMap<String, Peripheral> {
+    let mut peripherals = HashMap::new();
+    let mut invalid_peripherals = vec![];
+    let mut invalid_files = vec![];
+    let mut invalid_registers = vec![];
+    // let mut invalid_bit_fields = vec![];
+
+    let mut interrupts = vec![];
+
+    let filname = SOC_BASE_PATH.to_owned() + "eagle_soc.h";
+    let re_reg = Regex::new(REG_DEF).unwrap();
+    let re_reg_index = Regex::new(REG_DEF_INDEX).unwrap();
+    let re_reg_offset = Regex::new(REG_DEF_OFFSET).unwrap();
+    let re_reg_define = Regex::new(REG_DEFINE_MASK).unwrap();
+    let re_reg_define_shift = Regex::new(REG_DEFINE_SHIFT).unwrap();
+    let re_interrupts = Regex::new(INTERRUPTS).unwrap();
+    let re_single_bit = Regex::new(SINGLE_BIT).unwrap();
+    let re_reg_skip = Regex::new(REG_DEFINE_SKIP).unwrap();
+    let re_ifdef = Regex::new(REG_IFDEF).unwrap();
+    let re_endif = Regex::new(REG_ENDIF).unwrap();
+
+    let soc_h = file_to_string(&filname);
+
+    for captures in re_interrupts.captures_iter(soc_h.as_str()) {
+        let name = &captures[1];
+        let index = &captures[2];
+        let desc = &captures[3];
+        let intr = Interrupt {
+            name: name.to_string(),
+            description: Some(desc.to_string()),
+            value: index.parse().unwrap(),
+        };
+        interrupts.push(intr);
+        // println!("{:#?}", intr);
+    }
+
+    /*
+       Theses are indexed, we seed these as they cannot be derived from the docs
+       These blocks are identical, so we need to do some post processing to properly index
+       and offset these
+    */
+    // peripherals.insert("I2C".to_string(), Peripheral::default());
+    // peripherals.insert("SPI".to_string(), Peripheral::default());
+    // peripherals.insert("TIMG".to_string(), Peripheral::default());
+    // peripherals.insert("MCPWM".to_string(), Peripheral::default());
+    // peripherals.insert("UHCI".to_string(), Peripheral::default());
+
+    add_base_addr(&soc_h, &mut peripherals);
+
+    std::fs::read_dir(SOC_BASE_PATH)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|f| {
+            f.path().to_str().unwrap().ends_with("_register.h")
+                || f.file_name().to_str().unwrap() == "eagle_soc.h"
+        })
+        .for_each(|f| {
+            let name = f.path();
+            let name = name.to_str().unwrap();
+            // let mut buffer = vec![];
+            let mut file_data = file_to_string(name);
+            for (search, replace) in REPLACEMENTS {
+                file_data = file_data.replace(search, replace);
+            }
+
+            for (search, replace) in REPLACEMENTS_REGEX {
+                let re = Regex::new(search).unwrap();
+                file_data = re.replace_all(&file_data, *replace).to_string();
+            }
+
+            add_base_addr(&file_data, &mut peripherals);
+
+            // println!("Searching {}", name);
+            let mut something_found = false;
+            let mut state = State::FindReg;
+            for (i, line) in file_data.lines().enumerate() {
+                if re_ifdef.is_match(line) {
+                    continue;
+                } else if re_endif.is_match(line) {
+                    continue;
+                }
+
+                loop {
+                    match state {
+                        State::FindReg => {
+                            /* Normal register definitions */
+                            if let Some(m) = re_reg.captures(line) {
+                                let reg_name = &m[1];
+                                let pname = &m[2];
+                                let offset = &m[3].trim_start_matches("0x");
+                                if reg_name.ends_with("(i)") {
+                                    invalid_registers.push(reg_name.to_string());
+                                    // some indexed still get through, ignore them
+                                    break;
+                                }
+                                if let Ok(addr) = u32::from_str_radix(offset, 16) {
+                                    let mut r = Register::default();
+                                    r.description = reg_name.to_string();
+                                    r.name = reg_name.to_string();
+                                    r.address = addr;
+                                    state = State::FindBitFieldMask(pname.to_string(), r);
+                                } else {
+                                    invalid_registers.push(reg_name.to_string());
+                                }
+                            } else if let Some(m) = re_reg_index.captures(line) {
+                                let reg_name = &m[1];
+                                let pname = &m[2];
+                                let offset = &m[3].trim_start_matches("0x");
+
+                                if let Ok(addr) = u32::from_str_radix(offset, 16) {
+                                    let mut r = Register::default();
+                                    r.name = reg_name.to_string();
+                                    r.description = reg_name.to_string();
+                                    r.address = addr;
+                                    state = State::FindBitFieldMask(pname.to_string(), r);
+                                } else {
+                                    invalid_registers.push(reg_name.to_string());
+                                }
+                            } else if let Some(m) = re_reg_offset.captures(line) {
+                                let reg_name = &m[1];
+                                let offset = &m[2];
+                                let pname = reg_name.split('_').next().unwrap();
+
+                                if let Ok(addr) = u32::from_str_radix(offset, 16) {
+                                    let mut r = Register::default();
+                                    r.name = reg_name.to_string();
+                                    r.description = reg_name.to_string();
+                                    r.address = addr;
+                                    state = State::FindBitFieldMask(pname.to_string(), r);
+                                } else {
+                                    invalid_registers.push(reg_name.to_string());
+                                }
+                            }
+                            break; // next line
+                        }
+                        State::AssumeFullRegister(ref mut pname, ref mut reg) => {
+                            something_found = true;
+                            // assume full 32bit wide field
+                            let bitfield = BitField {
+                                name: "Register".to_string(),
+                                bits: Bits::Range(0..=31),
+                                ..Default::default()
+                            };
+                            reg.bit_fields.push(bitfield);
+
+                            if let Some(p) = peripherals.get_mut(&pname.to_string()) {
+                                p.registers.push(reg.clone());
+                            } else {
+                                invalid_peripherals.push(pname.to_string());
+                            }
+                            state = State::FindReg;
+                        }
+                        State::FindBitFieldMask(ref mut pname, ref mut reg) => {
+                            if re_reg_skip.is_match(line) {
+                                break;
+                            }
+
+                            if re_reg_offset.is_match(line) {
+                                state = State::AssumeFullRegister(pname.clone(), reg.clone());
+                                continue;
+                            }
+                            if let Some(m) = re_reg_define.captures(line) {
+                                something_found = true;
+                                let define_name = &m[1];
+                                let value = &m[2].trim_start_matches("0x");
+
+                                if let Some(m) = re_single_bit.captures(value) {
+                                    if let Ok(mask_bit) = u8::from_str_radix(&m[1], 10) {
+                                        let bitfield = BitField {
+                                            name: define_name.to_string(),
+                                            bits: Bits::Single(mask_bit),
+                                            ..Default::default()
+                                        };
+                                        reg.bit_fields.push(bitfield);
+                                        state = State::FindBitFieldSkipShift(
+                                            pname.clone(),
+                                            reg.clone(),
+                                        );
+                                        break;
+                                    } else {
+                                        println!(
+                                            "Failed to single bit match reg mask at {}:{}",
+                                            name, i
+                                        );
+                                        state = State::FindReg;
+                                    }
+                                } else if let Ok(mask) = u32::from_str_radix(value, 16) {
+                                    state =
+                                        State::FindBitFieldShift(pname.clone(), reg.clone(), mask);
+                                }
+                            } else {
+                                if reg.bit_fields.is_empty() {
+                                    state = State::AssumeFullRegister(pname.clone(), reg.clone());
+                                    continue;
+                                } else {
+                                    println!("Failed to match reg mask at {}:{}", name, i);
+                                    state = State::End(pname.clone(), reg.clone());
+                                }
+                            }
+                            break; // next line
+                        }
+                        State::FindBitFieldShift(ref mut pname, ref mut reg, ref mut mask) => {
+                            if re_reg_skip.is_match(line) {
+                                break;
+                            }
+                            if let Some(m) = re_reg_define_shift.captures(line) {
+                                let define_name = &m[1];
+                                let value = &m[2];
+
+                                if let Ok(shift) = u8::from_str_radix(value, 10) {
+                                    let bitfield = BitField {
+                                        name: define_name.to_string(),
+                                        bits: match mask.count_ones() {
+                                            1 => Bits::Single(shift),
+                                            bits => Bits::Range(shift..=shift + (bits - 1) as u8),
+                                        },
+                                        ..Default::default()
+                                    };
+                                    reg.bit_fields.push(bitfield);
+                                    state = State::CheckEnd(pname.clone(), reg.clone())
+                                }
+                            } else {
+                                if reg.bit_fields.is_empty() {
+                                    state = State::AssumeFullRegister(pname.clone(), reg.clone());
+                                    continue;
+                                } else {
+                                    println!(
+                                        "Failed to match reg shift at {}:{} ('{}')",
+                                        name, i, line
+                                    );
+                                    state = State::End(pname.clone(), reg.clone());
+                                }
+                            }
+                            break; // next line
+                        }
+                        State::FindBitFieldSkipShift(ref mut pname, ref mut reg) => {
+                            state = State::CheckEnd(pname.clone(), reg.clone());
+                            if re_reg_define_shift.is_match(line) {
+                                break;
+                            }
+                        }
+                        State::CheckEnd(ref mut pname, ref mut reg) => {
+                            if line.is_empty() {
+                                state = State::End(pname.clone(), reg.clone());
+                                break;
+                            } else if re_reg_define.is_match(line) {
+                                // we've found the next bit field in the reg
+                                state = State::FindBitFieldMask(pname.clone(), reg.clone());
+                            } else {
+                                break; // next line
+                            }
+                        }
+                        State::End(ref mut pname, ref mut reg) => {
+                            if let Some(p) = peripherals.get_mut(&pname.to_string()) {
+                                p.registers.push(reg.clone());
+                            } else {
+                                // TODO indexed peripherals wont come up here
+                                // println!("No periphal called {}", pname.to_string());
+                                invalid_peripherals.push(pname.to_string());
+                            }
+                            state = State::FindReg;
+                        }
+                    }
+                }
+            }
+
+            // log if nothing was parsed in this file
+            if !something_found {
+                invalid_files.push(String::from(name))
+            }
+        });
+
+    println!("Parsed idf for peripherals information.");
+
+    if invalid_files.len() > 0 {
+        println!(
+            "The following files contained no parsable information {:?}",
+            invalid_files
+        );
+    }
+
+    if invalid_peripherals.len() > 0 {
+        println!(
+            "The following peripherals failed to parse {:?}",
+            invalid_peripherals
+        );
+    }
+
+    if invalid_registers.len() > 0 {
+        println!(
+            "The following registers failed to parse {:?}",
+            invalid_registers
+        );
+    }
+
+    // if invalid_bit_fields.len() > 0 {
+    //     println!(
+    //         "The following bit_fields failed to parse {:?}",
+    //         invalid_bit_fields
+    //     );
+    // }
+
+    // println!("Interrupt information: {:#?}", interrupts);
+
+    peripherals
+}
+
+fn file_to_string(fil: &str) -> String {
+    let mut soc = File::open(fil).unwrap();
+    let mut data = String::new();
+    soc.read_to_string(&mut data).unwrap();
+    data
+}
+
+fn build_svd(peripherals: HashMap<String, Peripheral>) -> Result<SvdDevice, ()> {
+    let mut svd_peripherals = vec![];
+
+    for (name, p) in peripherals {
+        let mut registers = vec![];
+        for r in p.registers {
+            let mut fields = vec![];
+            for field in &r.bit_fields {
+                let description = if field.description.trim().is_empty() {
+                    None
+                } else {
+                    Some(field.description.clone())
+                };
+
+                let bit_range = match &field.bits {
+                    Bits::Single(bit) => BitRange {
+                        offset: u32::from(*bit),
+                        width: 1,
+                        range_type: BitRangeType::OffsetWidth,
+                    },
+                    Bits::Range(r) => BitRange {
+                        offset: u32::from(*r.start()),
+                        width: u32::from(r.end() - r.start() + 1),
+                        range_type: BitRangeType::OffsetWidth,
+                    },
+                };
+
+                let field_out = FieldInfoBuilder::default()
+                    .name(field.name.clone())
+                    .description(description)
+                    .bit_range(bit_range)
+                    .access(Some(field.type_.into()))
+                    .build()
+                    .unwrap();
+                fields.push(Field::Single(field_out));
+            }
+
+            let info = RegisterInfoBuilder::default()
+                .name(r.name.clone())
+                .description(Some(r.description.clone()))
+                .address_offset(r.address)
+                .size(Some(32))
+                .reset_value(Some(r.reset_value as u32))
+                .fields(Some(fields))
+                .build()
+                .unwrap();
+
+            registers.push(RegisterCluster::Register(SvdRegister::Single(info)));
+        }
+        let block_size = registers.iter().fold(0, |sum, reg| {
+            sum + match reg {
+                RegisterCluster::Register(r) => r.size.unwrap(),
+                _ => unimplemented!(),
+            }
+        });
+        let out = PeripheralBuilder::default()
+            .name(name.to_owned())
+            .base_address(p.address)
+            .registers(Some(registers))
+            .address_block(Some(AddressBlock {
+                offset: 0x0,
+                size: block_size, // TODO what about derived peripherals?
+                usage: "registers".to_string(),
+            }))
+            .build()
+            .unwrap();
+
+        svd_peripherals.push(out);
+    }
+
+    svd_peripherals.sort_by(|a, b| a.name.cmp(&b.name));
+
+    println!("Len {}", svd_peripherals.len());
+
+    let cpu = CpuBuilder::default()
+        .name("Xtensa LX106".to_string())
+        .revision("1".to_string())
+        .endian(Endian::Little)
+        .mpu_present(false)
+        .fpu_present(true)
+        // according to https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/system/intr_alloc.html#macros
+        // 7 levels so 3 bits? //TODO verify
+        .nvic_priority_bits(3)
+        .has_vendor_systick(false)
+        .build()
+        .unwrap();
+
+    let device = DeviceBuilder::default()
+        .name("Espressif".to_string())
+        .version(Some("1.0".to_string()))
+        .schema_version(Some("1.0".to_string()))
+        // broken see: https://github.com/rust-embedded/svd/pull/104
+        // .description(Some("ESP32".to_string()))
+        // .address_unit_bits(Some(8))
+        .width(Some(32))
+        .cpu(Some(cpu))
+        .peripherals(svd_peripherals)
+        .build()
+        .unwrap();
+
+    Ok(device)
+}
+
 pub fn create_svd() {
-    // TODO: implement me
-    unimplemented!()
+    let mut peripherals = parse_sdk();
+
+    // where available, the docs provide more detailed info
+    peripherals
+        .iter_mut()
+        .for_each(|(name, peripheral)| match name.as_str() {
+            "TIMER" => {
+                let doc_peripheral = parse_doc("build/timer.json");
+                peripheral.registers = doc_peripheral.registers;
+            }
+            "GPIO" => {
+                let doc_peripheral = parse_doc("build/gpio.json");
+                peripheral.registers = doc_peripheral.registers;
+            }
+            _ => {}
+        });
+
+    let mut uart_peripheral_0 = parse_doc("build/uart.json");
+    let mut uart_peripheral_1 = uart_peripheral_0.clone();
+    uart_peripheral_0.address = 0x60000000;
+    uart_peripheral_1.address = 0x60000f00;
+    peripherals.insert("UART0".to_string(), uart_peripheral_0);
+    peripherals.insert("UART1".to_string(), uart_peripheral_1);
+
+    let mut spi = parse_doc("build/spi.json");
+    spi.address = 0x60000200;
+    for i in 0..16 {
+        spi.registers.push(Register {
+            name: format!("SPI_W{}", i),
+            address: 0x40 + (i * 32),
+            width: 32,
+            description: format!("the data inside the buffer of the SPI module, byte {}", i),
+            reset_value: 0,
+            bit_fields: vec![BitField {
+                name: format!("spi_w{}", i),
+                bits: Bits::Range(0..=31),
+                type_: Type::ReadWrite,
+                reset_value: 0,
+                description: format!("the data inside the buffer of the SPI module, byte {}", i),
+            }],
+            detailed_description: None,
+        })
+    }
+    peripherals.insert("SPI".to_string(), spi);
+
+    let svd = build_svd(peripherals).unwrap();
+
+    let f = BufWriter::new(File::create("esp8266.svd").unwrap());
+    svd.encode().unwrap().write(f).unwrap();
 }


### PR DESCRIPTION
This is based on the work done by @icewind1991, available [here](https://github.com/icewind1991/idf2svd/tree/esp8266), to generate an SVD file for the ESP8266. Just thought it'd be good to have everything under one roof.

I basically just created a simple CLI utility using [clap](https://github.com/clap-rs/clap) which allows you to generate either file using `cargo run esp32` or `cargo run esp8266`, and pulled in the aforementioned code. The bits specific to the ESP32 are in the `idf` module, and for the ESP8266 in the `sdk` module. A small refactor was then done and some code was extracted into the `common` module.

The ESP8266 requires invoking the `Makefile` prior to running the application, which as been documented in the `README`.

I have also updated `Cargo.toml` to include some additional metadata. The version number has already been incremented as well. Additionally I added the license files (I'm just assuming on these, let me know if you'd like to use something else).

I'm not really sure what to call this anymore since the ESP8266 doesn't use esp-idf, so I've just used `header2svd` for now. I can change this if we come up with something better.

As far as I can tell everything is working as expected. If you find any problems or would like any further changes made please just let me know and I'll be happy to take care of it.