### PR TITLE
Set correct device name

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -119,6 +119,7 @@ pub fn file_to_string(file: &str) -> String {
 }
 
 pub fn build_svd(
+    device_name: String,
     cpu_name: String,
     peripherals: HashMap<String, Peripheral>,
 ) -> Result<SvdDevice, ()> {
@@ -213,7 +214,7 @@ pub fn build_svd(
         .unwrap();
 
     let device = DeviceBuilder::default()
-        .name("Espressif".to_string())
+        .name(device_name)
         .version(Some("1.0".to_string()))
         .schema_version(Some("1.0".to_string()))
         // broken see: https://github.com/rust-embedded/svd/pull/104

--- a/src/idf/mod.rs
+++ b/src/idf/mod.rs
@@ -247,9 +247,10 @@ fn parse_idf() -> HashMap<String, Peripheral> {
 }
 
 pub fn create_svd() {
+    let device_name = String::from("esp32");
     let cpu_name = String::from("Xtensa LX6");
     let peripherals = parse_idf();
-    let svd = build_svd(cpu_name, peripherals).unwrap();
+    let svd = build_svd(device_name, cpu_name, peripherals).unwrap();
 
     let f = BufWriter::new(File::create("esp32.svd").unwrap());
     svd.encode().unwrap().write(f).unwrap();

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -428,8 +428,9 @@ pub fn create_svd() {
     }
     peripherals.insert("SPI".to_string(), spi);
 
+    let device_name = String::from("esp8266");
     let cpu_name = String::from("Xtensa LX106");
-    let svd = build_svd(cpu_name, peripherals).unwrap();
+    let svd = build_svd(device_name, cpu_name, peripherals).unwrap();
 
     let f = BufWriter::new(File::create("esp8266.svd").unwrap());
     svd.encode().unwrap().write(f).unwrap();


### PR DESCRIPTION
Regarding the root `<name>` element: http://www.keil.com/pack/doc/CMSIS/SVD/html/elem_device.html

> The string identifies the device or device series. Device names are required to be unique.

Hardcoding the string `Espressif` is not unique. In most other SVD files I've seen the name is the chip name. Hence this PR to fix that.
I use the chip name for my own SVD to Go converter, the name is used as the output file name.