### PR TITLE
Alway create the registers xml field on peripherals

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -231,11 +231,7 @@ pub fn build_svd(
         let out = PeripheralBuilder::default()
             .name(name.to_owned())
             .base_address(p.address as u64)
-            .registers(if registers.is_empty() {
-                None
-            } else {
-                Some(registers)
-            })
+            .registers(Some(registers))
             .address_block(Some(AddressBlock {
                 offset: 0x0,
                 size: block_size, // TODO what about derived peripherals?


### PR DESCRIPTION
Alway create the registers xml field on peripherals, even if its empty. We need the field to be present for svd-patch to work.